### PR TITLE
brcmfmac: Use request_firmware_direct for the clm_blob

### DIFF
--- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/common.c
+++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/common.c
@@ -199,7 +199,7 @@ static int brcmf_c_process_clm_blob(struct brcmf_if *ifp)
 		return err;
 	}
 
-	err = request_firmware(&clm, clm_name, dev);
+	err = request_firmware_direct(&clm, clm_name, dev);
 	if (err) {
 		brcmf_info("no clm_blob available(err=%d), device may have limited channels available\n",
 			   err);


### PR DESCRIPTION
    from patchwork.kernel.org:

    The linux-firmware brcmfmac firmware files contain an embedded table with
    per country allowed channels and strength info.

    These versions of the firmware are specially build for linux-firmware,
    the firmware files directly available from Broadcom / Cypress rely on
    a separate clm_blob file for this info.

    For some unknown reason Broadcom / Cypress refuse to provide the standard
    firmware files + clm_blob files it uses elsewhere for inclusion into
    linux-firmware, instead relying on these special builds with the clm_blob
    info embedded. This means that the linux-firmware firmware versions often
    lag behind, but I digress.

    The brcmfmac driver does support the separate clm_blob file and always
    tries to load this. Currently we use request_firmware for this. This means
    that on any standard install, using the standard combo of linux-kernel +
    linux-firmware, we will get a warning:
    "Direct firmware load for ... failed with error -2"

    On top of this, brcmfmac itself prints: "no clm_blob available (err=-2),
    device may have limited channels available" and we will get a slow
    fallback to the userspace firmware loading mechanism.

    This commit fixes both almost any brcmfmac device logging the warning
    (leaving the brcmfmac info message in pace), as well as the slow and
    unnecesary fallback by switching to request_firmware_direct for
    the clm_blob.